### PR TITLE
Exposing the service's port in the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,6 @@ COPY package*.json ./
 RUN npm install lodash
 RUN npm install
 COPY . .
+
+EXPOSE 9005
 CMD [ "npm", "start" ]


### PR DESCRIPTION
This change enables docker users to use the -P flag to automatically map local ports to the exposed ports.