### PR TITLE
Optimized Dockerfile (1.54 GB -> 498 MB)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.dockerignore
+.git
+info
+readme/
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM node:latest
-RUN apt-get update && apt-get install -y firefox-esr tesseract-ocr
+FROM node:14.15.3-alpine3.12
 WORKDIR /usr/src/app
-COPY package*.json ./
-RUN npm install lodash
-RUN npm install
 COPY . .
+RUN apk update && \
+  apk add --no-cache firefox-esr tesseract-ocr && \
+  npm install lodash && \
+  npm install
 EXPOSE 9005
-CMD [ "npm", "start" ]
+ENTRYPOINT [ "npm", "start" ]

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ python3 app.py -c -m "fast" -u "username" -w "youtube pinterest tumblr"
 ```bash
 git clone https://github.com/qeeqbox/social-analyzer.git
 cd social-analyzer
-sudo docker build -t social-analyzer . && sudo docker run -p 9005:9005 -it social-analyzer
+docker build -t social-analyzer . && docker run -p 9005:9005 -it social-analyzer
 ```
 
 ## Running Issues


### PR DESCRIPTION
This updates the Dockerfile so the image can build faster, and build with an overall smaller size.

### Added a `.dockerignore`
I added a `.dockerignore` which reduces the size of the build context before building. This alone reduced the image from 1.53 GB to 1.47 GB.

> \- https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#exclude-with-dockerignore

### Used an Alpine version of Node
Alpine is a stripped down OS which is great for building lighter images. Using a larger OS makes the image a lot bulkier and often provides more tools installed which can increase the vulnerability surface of the container. This pulled the image size down from 1.47 GB to 498 MB.

> Whenever possible, use current official images as the basis for your images. We recommend the Alpine image as it is tightly controlled and small in size (currently under 5 MB), while still being a full Linux distribution.
> \- <https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#dockerfile-instructions> 

### General Good Practices
#### Specify a Specific Image Version
Using `node:latest` isn't the best idea because the `Dockerfile` may unexpectedly break at some point once a certain non-backward compatible version of Node is released. By specifying a version you have a guarantee that it'll always fetch the correct image that we _know_ works for this project. For this PR, I tested and picked out the latest LTS version.

#### Reduce Image Layers
A Docker container has "Layers", doing commands like `RUN`, `COPY`, or `ADD` create new layers in the image, which can increase image size (but not in this case) and slow down the build. It's optimal to merge these into single commands where possible.

---

I've also updated the `README.md` to no longer use `sudo`, since when doing Docker commands it shouldn't be required.