### PR TITLE
Address NPM Warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,9 @@
     "yargs": "16.2.0"
   },
   "author": "QeeqBox",
-  "license": "AGPL 3.0"
+  "license": "AGPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/qeeqbox/social-analyzer"
+  }
 }


### PR DESCRIPTION
This updates the `package.json` to remove some warnings that appear during `npm install`.

Adds the `repository` field.
```bash
npm WARN social-analyzer@2.0.2 No repository field.
```

Adds a hyphen to the license string.
```bash
npm WARN social-analyzer@2.0.2 license should be a valid SPDX license expression
```