### PR TITLE
Removed duplicate hubpages.com

### DIFF
--- a/data/site_updated.json
+++ b/data/site_updated.json
@@ -7187,29 +7187,6 @@
       "type": "unavailable"
     },
     {
-      "url": "https://{username}.hubpages.com",
-      "detections": [{
-          "return": "false",
-          "string": "Page does not exist",
-          "type": "ocr"
-        },
-        {
-          "return": "false",
-          "string": "Page does not exist",
-          "type": "normal"
-        },
-        {
-          "return": "true",
-          "string": "\"profile\"",
-          "type": "normal"
-        }
-      ],
-      "selected": "false",
-      "timeout": 0,
-      "implicit": 0,
-      "type": "unavailable"
-    },
-    {
       "url": "https://{username}.itch.io",
       "detections": [{
           "return": "false",

--- a/data/sites.json
+++ b/data/sites.json
@@ -7410,30 +7410,6 @@
       "type": "unavailable"
     },
     {
-      "url": "https://{username}.hubpages.com",
-      "detections": [{
-          "return": "false",
-          "string": "Page does not exist",
-          "type": "advanced"
-        },
-        {
-          "return": "false",
-          "string": "Page does not exist",
-          "type": "normal"
-        },
-        {
-          "return": "true",
-          "string": "\"profile\"",
-          "type": "normal"
-        }
-      ],
-      "selected": "false",
-      "timeout": 0,
-      "implicit": 0,
-      "extract": [],
-      "type": "unavailable"
-    },
-    {
       "url": "https://{username}.itch.io",
       "detections": [{
           "return": "false",


### PR DESCRIPTION
I can see HubPages appears twice in this list.
I checked out the detections and see there are two:

![image](https://user-images.githubusercontent.com/22801583/109987967-5d63d980-7d07-11eb-8cc1-fec8de71408c.png)

1. https://example.hubpages.com/
2. https://hubpages.com/@example

However, the 1st link just does a 301 redirect to the 2nd one.
I don't _think_ there is any need to have the same detections twice for what is essentially going to run on the same page.

![image](https://user-images.githubusercontent.com/22801583/109988147-8a17f100-7d07-11eb-9b18-14c311cb3f3f.png)

This PR removes `https://{username}.hubpages.com/`, as this is the one that gets redirected.