### PR TITLE
Fixed 'charmap' codec can't decode byte 0x8f

### DIFF
--- a/app.py
+++ b/app.py
@@ -649,7 +649,6 @@ class SocialAnalyzer():
                 with open(path_to_check,encoding="utf-8") as f:
                     ret = load(f)
         except Exception as e:
-            print(e)
             self.print_wrapper("[!] {} Does not exist! cannot be downloaded...".format(name))
         return ret
 

--- a/app.py
+++ b/app.py
@@ -646,9 +646,10 @@ class SocialAnalyzer():
                     f.write(file.content)
             if path.exists(path_to_check) == True:
                 self.print_wrapper("[init] {} looks good!".format(name))
-                with open(path_to_check) as f:
+                with open(path_to_check,encoding="utf-8") as f:
                     ret = load(f)
         except Exception as e:
+            print(e)
             self.print_wrapper("[!] {} Does not exist! cannot be downloaded...".format(name))
         return ret
 


### PR DESCRIPTION
Fixed an error in load_file() function that occured while reading some character. Simply precised an encoding (UTF-8) as optionnal argument of open() function and read the sites.json file properly. The error occured on windows 10 with python 3.9.5