### PR TITLE
fix: remove bintray from sites

### DIFF
--- a/clean-up.logs
+++ b/clean-up.logs
@@ -1,4 +1,4 @@
-Thu Sep 16 21:36:23 UTC 2021
+Mon Sep 20 12:13:20 UTC 2021
 [X] social-analyzer
 [X] installing autopep8 & jq
 [X] running autopep8

--- a/clean-up.logs
+++ b/clean-up.logs
@@ -1,3 +1,4 @@
+Tue Sep 21 17:10:03 UTC 2021
 [X] social-analyzer
 [X] installing autopep8 & jq
 [X] running autopep8

--- a/data/sites.json
+++ b/data/sites.json
@@ -1345,34 +1345,6 @@
       "country_code": 0
     },
     {
-      "url": "https://bintray.com/{username}",
-      "detections": [
-        {
-          "return": "false",
-          "string": "Page not found",
-          "type": "normal"
-        },
-        {
-          "return": "true",
-          "string": "profile-name",
-          "type": "normal"
-        },
-        {
-          "return": "true",
-          "string": "titlebar-details",
-          "type": "normal"
-        }
-      ],
-      "selected": "false",
-      "timeout": 0,
-      "implicit": 0,
-      "extract": [],
-      "type": "Computers Electronics and Technology > Programming and Developer Software",
-      "global_rank": 47188,
-      "country": "IN",
-      "country_code": 0
-    },
-    {
       "url": "https://biosector01.com/wiki/User:{username}",
       "detections": [
         {

--- a/data/sites.json_new
+++ b/data/sites.json_new
@@ -1345,34 +1345,6 @@
       "country_code": 0
     },
     {
-      "url": "https://bintray.com/{username}",
-      "detections": [
-        {
-          "return": "false",
-          "string": "Page not found",
-          "type": "normal"
-        },
-        {
-          "return": "true",
-          "string": "profile-name",
-          "type": "normal"
-        },
-        {
-          "return": "true",
-          "string": "titlebar-details",
-          "type": "normal"
-        }
-      ],
-      "selected": "false",
-      "timeout": 0,
-      "implicit": 0,
-      "extract": [],
-      "type": "Computers Electronics and Technology > Programming and Developer Software",
-      "global_rank": 47188,
-      "country": "IN",
-      "country_code": 0
-    },
-    {
       "url": "https://biosector01.com/wiki/User:{username}",
       "detections": [
         {


### PR DESCRIPTION
Bintray was sunset a while back, so the site and detections are no longer relevant.

Where trying to access any profile looks like now:  
![image](https://user-images.githubusercontent.com/22801583/134000369-1af5f85c-2f82-4148-a3da-f5882d6946d7.png)
