### PR TITLE
Fix error 'SE_EVENT_BUS_HOST not set, exiting!'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,10 +23,10 @@ services:
     depends_on:
       - hub
     environment:
-      HUB_PORT_4444_TCP_ADDR: hub
-      HUB_PORT_4444_TCP_PORT: 4444
-      NODE_MAX_SESSION: 2
-      NODE_MAX_INSTANCES: 10
+      SE_EVENT_BUS_HOST: hub
+      SE_EVENT_BUS_PUBLISH_PORT: 4442
+      SE_EVENT_BUS_SUBSCRIBE_PORT: 4443
+      SE_NODE_MAX_SESSIONS: ${CPU_CORES:-2}
     volumes:
       - /dev/shm:/dev/shm
     ports:


### PR DESCRIPTION
## Issue

As the version for the `selenium/node-firefox` image is not fixed, the environment variables needs to be adjusted accordingly.
I've added `CPU_CORES` as an external variable that can be adjusted or defaults to `2` CPU cores.

## Context

During some testing sessions, I had some hard times to figure why the screenshot feature was not working as expected. After few hours of debugging, I've found the culprit 😅 

```
web-automation_firefox | SE_EVENT_BUS_HOST not set, exiting!
web-automation_firefox | 2021-12-04 01:54:01,992 INFO exited: selenium-node (exit status 1; not expected)
```

I then did some research and found that the defined variables was not correct anymore, certainly due to version changes since last time the `docker-compose.yml` has been created and/or updated.

## Fix proofs

From logs:

```
web-automation_firefox | Generating Selenium Config
web-automation_firefox | Configuring server...
web-automation_firefox | Setting up SE_NODE_HOST...
web-automation_firefox | Setting up SE_NODE_PORT...
web-automation_firefox | Setting up SE_NODE_GRID_URL...
web-automation_firefox | Selenium Grid Node configuration: 
web-automation_firefox | [events]
web-automation_firefox | publish = "tcp://hub:4442"
web-automation_firefox | subscribe = "tcp://hub:4443"
web-automation_firefox | 
web-automation_firefox | [node]
web-automation_firefox | session-timeout = "300"
web-automation_firefox | override-max-sessions = false
web-automation_firefox | detect-drivers = false
web-automation_firefox | max-sessions = 4
web-automation_firefox | 
web-automation_firefox | [[node.driver-configuration]]
web-automation_firefox | display-name = "firefox"
web-automation_firefox | stereotype = '{"browserName": "firefox", "browserVersion": "94.0", "platformName": "Linux"}'
web-automation_firefox | max-sessions = 4
web-automation_firefox | 
web-automation_firefox | Starting Selenium Grid Node...
```

Using command:

```bash
echo "CPU_CORES=`nproc`" > .env ; docker-compose -f docker-compose.yml up --build
```

Could also be invoked as shown in the documentation:

```bash
docker-compose -f docker-compose.yml up --build
```

This will simply set the `SE_NODE_MAX_SESSIONS` variable to the default value, which is `2` CPU cores.

> The variable `SE_NODE_OVERRIDE_MAX_SESSIONS: "true"` could have been added too but this might create some overloads if running on a server that don't have more than 2 CPU cores as it would bypass the limit fixed by the `SE_NODE_MAX_SESSIONS` variable.

## Screenshots

![image](https://user-images.githubusercontent.com/9881407/144696271-9b09de2e-1528-428a-a3c4-984137d5ba30.png)
![image](https://user-images.githubusercontent.com/9881407/144696377-f365f4e4-e91c-4fd2-a1f9-34864852cab2.png)
![image](https://user-images.githubusercontent.com/9881407/144696910-b7d5b8cf-80f4-48f9-81a2-48a65af1cd8b.png)


## Documentation updates

If this pull request is accepted, then the [install instructions](https://github.com/qeeqbox/social-analyzer/wiki/install#docker-compose) should be adjusted to explain that the deployment can be adjusted using the following ways for example:

```bash
# By default (2 CPU cores)
docker-compose -f docker-compose.yml up --build

# Using all available CPU cores
echo "CPU_CORES=`nproc`" > .env ; docker-compose -f docker-compose.yml up --build

# Using only some CPU cores (if more than 4)
echo "CPU_CORES=4" > .env ; docker-compose -f docker-compose.yml up --build
```