### PR TITLE
Add galeodes to the requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ termcolor
 langdetect
 requests
 lxml
+galeodes


### PR DESCRIPTION
Prior to this change, after running `pip install -r requirements.txt`
The user wouldn't be able to run the project as a python script, with an
error `ModuleNotFoundError: No module named 'galeodes'`
