### PR TITLE
Update slow-scan.js - import() function to import the CommonJS module…

### DIFF
--- a/modules/slow-scan.js
+++ b/modules/slow-scan.js
@@ -9,8 +9,10 @@ import path from 'path'
 import engine from './engine.js'
 
 if (process.platform === 'win32') {
-  const package_path = path.join(path.dirname(require.resolve('geckodriver')), '..')
-  process.env.PATH = process.env.PATH + ';' + package_path
+  import('./geckodriver-path.cjs').then((geckodriverPath) => {
+    const package_path = path.join(geckodriverPath, '..');
+    process.env.PATH = process.env.PATH + ';' + package_path;
+  });
 }
 
 async function find_username_advanced (req) {


### PR DESCRIPTION
… asynchronously

workaround to ReferenceError: require is not defined in ES module scope, you can use import instead