### PR TITLE
Fix use of CommonJS require.resolve

### DIFF
--- a/modules/slow-scan.js
+++ b/modules/slow-scan.js
@@ -4,9 +4,12 @@ import extraction from './extraction.js'
 import async from 'async'
 import sanitizeHtml from 'sanitize-html'
 import firefox from 'selenium-webdriver/firefox.js'
-import {Builder,By,Key} from 'selenium-webdriver'
+import {Builder,By} from 'selenium-webdriver'
 import path from 'path'
 import engine from './engine.js'
+import {createRequire} from 'node:module';
+
+const require = createRequire(import.meta.url);
 
 if (process.platform === 'win32') {
   const package_path = path.join(path.dirname(require.resolve('geckodriver')), '..')


### PR DESCRIPTION
Fixes #109 .

Root cause was the use of CommonJS `require.resolve` in an ESM module (`slow-scan.js`). Fortunately, Node provides a helper function [module.createRequire](https://nodejs.org/docs/latest-v18.x/api/module.html#modulecreaterequirefilename) for this case.