### PR TITLE
removing windows blocker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3120,9 +3120,6 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/n/-/n-8.2.0.tgz",
       "integrity": "sha512-qv+jwJoXaV94C+uASaLS/Qe/iprgvQKe+5hqg6YvUH8mqe5ysgjby875pUVLLWieGFywipEO/J/bgekYbC18Jw==",
-      "os": [
-        "!win32"
-      ],
       "bin": {
         "n": "bin/n"
       },


### PR DESCRIPTION
I was using windows following the guide on:

https://github.com/qeeqbox/social-analyzer/wiki/install 

Windows (As Node WebApp)

When running `npm ci` the console throws an error: 

```npm error code EBADPLATFORM
npm error notsup Unsupported platform for n@8.2.0: wanted {"os":"!win32"} (current: {"os":"win32"})
npm error notsup Valid os:  !win32
npm error notsup Actual os: win32```

even though I'm using a windows 10 x64 version, so the check for the win32 is not correctly filtering windows between x32 and x64 so there is no point on keeping that check

<img width="783" height="390" alt="Captura de pantalla 2025-08-25 124115" src="https://github.com/user-attachments/assets/70a250ec-a5c8-4529-8fd9-a280f258732d" />

