### PR TITLE
Added min node version rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,9 @@
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.0.32",
   "description": "Advanced Social Media Profiles Finder and String Analysis Tool",
   "main": "app.js",
+  "engines": {
+    "node": ">=20.18.1"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node app.js --gui"


### PR DESCRIPTION
#### Issue & Cause
- for node version lower than 20, `cheerio` has min version dependancy.

<img width="1870" height="240" alt="install-error-yarn" src="https://github.com/user-attachments/assets/8b1d7950-a426-4696-b0f6-1a55e62292c7" />

#### Fix
- records min node version in `package.json`
- `npm install` will show a warning

<img width="626" height="109" alt="image" src="https://github.com/user-attachments/assets/933c966d-bb3b-422b-8950-f909676f0318" />
